### PR TITLE
Enables publishing to PyPI on tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ main, master ]
+    tags: ['v*.*.*']
   pull_request:
 
 concurrency:
@@ -104,8 +105,6 @@ jobs:
               print(f)
               sys.exit(0 if os.path.exists(f) else 1)
           PY
-
-
   build:
     name: Build & check sdists/wheels
     runs-on: ubuntu-latest
@@ -145,3 +144,30 @@ jobs:
               print(f)
               sys.exit(0 if os.path.exists(f) else 1)
           PY
+  publish:
+    name: Publish to PyPI (on tag)
+    if: startsWith(github.ref, 'refs/tags/v')   # only when pushing a v* tag
+    needs: [pre-commit, unit, rocky-smoke, build]  # gate on all the checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0       # needed if you use setuptools_scm
+          fetch-tags: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'   # choose your build interpreter
+
+      - name: Build sdist/wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ This prevents secrets from appearing in argv or logs.
 ## Project Links
 
 - PyPI: https://pypi.org/project/pg-provision/
-- Release 0.1.0: https://pypi.org/project/pg-provision/0.1.0/
+- Release 0.2.1: https://pypi.org/project/pg-provision/0.2.1/


### PR DESCRIPTION
Adds a new job to the CI workflow that publishes the package to PyPI when a tag is pushed.

Updates the README to point to the latest release on PyPI.