### PR TITLE
Adding self-healing for Ubuntu and RHEL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,10 +51,10 @@ repos:
       - id: shfmt
 
   # Shell linting
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
-    hooks:
-    -   id: shellcheck
+  -   repo: https://github.com/shellcheck-py/shellcheck-py
+      rev: v0.11.0.1
+      hooks:
+      -   id: shellcheck
 
   # Secrets scanning (kept to commit stage; uses repo baseline)
   - repo: https://github.com/Yelp/detect-secrets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,7 @@ repos:
       rev: v0.11.0.1
       hooks:
       -   id: shellcheck
+          args: ["-x"]
 
   # Secrets scanning (kept to commit stage; uses repo baseline)
   - repo: https://github.com/Yelp/detect-secrets

--- a/README.md
+++ b/README.md
@@ -193,4 +193,4 @@ This prevents secrets from appearing in argv or logs.
 ## Project Links
 
 - PyPI: https://pypi.org/project/pg-provision/
-- Release 0.2.4: https://pypi.org/project/pg-provision/0.2.4/
+- Release 0.2.5: https://pypi.org/project/pg-provision/0.2.5/

--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ ______________________________________________________________________
 - Ubuntu: [docs/test-plan-ubuntu.md](docs/test-plan-ubuntu.md)
 - RHEL/Rocky/Alma: [docs/test-plan-rhel.md](docs/test-plan-rhel.md)
 
+### Self‑Heal on Ubuntu (PGDG)
+
+On Ubuntu/Debian with PGDG, packaging normally creates a default `main` cluster. If that metadata is broken (e.g., `pg_lsclusters` errors, `/etc/postgresql/<ver>/main` owned by root, or `data_directory` missing), pg‑provision can self‑heal before applying HBA/profile/role changes.
+
+- Non‑destructive: it never deletes a directory that looks like a real PGDATA (has `PG_VERSION` and `global/pg_control`).
+- If a valid PGDATA exists, it rebuilds Debian metadata to point at it (adoption), then starts the service.
+- Default behavior is on; disable with `--no-self-heal` or `SELF_HEAL=false`.
+- See `docs/test-plan-ubuntu.md` for self‑heal scenarios.
+
+### Self‑Heal on RHEL (PGDG)
+
+On RHEL family (RHEL/Rocky/Alma/Fedora/Amazon Linux), the provisioner preflights the cluster and will adopt an existing valid `PGDATA` by setting a systemd override (`Environment=PGDATA=…`) and ensuring permissions/SELinux context. If no valid data exists, it initializes a fresh cluster using packaging helpers (`postgresql-setup`) or `initdb`.
+
+- Non‑destructive: never deletes a directory that looks like a real PGDATA.
+- See `docs/test-plan-rhel.md` for self‑heal scenarios.
+
 ## Notes
 
 - Linux-only. Commands that modify the system require root or passwordless sudo.

--- a/src/pgprovision/_sh/provision.sh
+++ b/src/pgprovision/_sh/provision.sh
@@ -130,6 +130,7 @@ PROFILE=${PROFILE:-}
 ENV_FILE=${ENV_FILE:-}
 DRY_RUN=${DRY_RUN:-false}
 INIT_PG_STAT_STATEMENTS=${INIT_PG_STAT_STATEMENTS:-false}
+SELF_HEAL=${SELF_HEAL:-true}
 
 # Local hardening flags
 SOCKET_ONLY=${SOCKET_ONLY:-}
@@ -148,6 +149,7 @@ Postgres Provisioner (PG16)
 Usage: $0 \
   [--repo pgdg|os] [--port N] [--listen-addresses VAL] [--allowed-cidr CIDR] [--allowed-cidr-v6 CIDR6] \\
   [--data-dir PATH|auto] [--enable-tls] [--init-pg-stat-statements] \\
+  [--no-self-heal] \\
   [--create-db NAME] [--create-user NAME] [--create-password SECRET] [--allow-network] [--profile NAME] [--env-file FILE] [--dry-run] \\
   [--socket-only] [--unix-socket-group NAME] [--unix-socket-permissions MODE] [--unix-socket-dir PATH] \\
   [--local-peer-map NAME] [--local-map-entry OSUSER:DBROLE]... [--admin-group-role NAME] [--admin-dbrole NAME] [--disable-postgres-login]
@@ -194,6 +196,10 @@ parse_args() {
 			;;
 		--init-pg-stat-statements)
 			INIT_PG_STAT_STATEMENTS=true
+			shift 1
+			;;
+		--no-self-heal)
+			SELF_HEAL=false
 			shift 1
 			;;
 		--create-db)

--- a/src/pgprovision/_sh/provision.sh
+++ b/src/pgprovision/_sh/provision.sh
@@ -637,6 +637,14 @@ main() {
 	os_detect
 	load_os_module
 
+	if [[ "${SELF_HEAL:-true}" == "true" ]]; then
+		if [[ "${OS_FAMILY}" == "ubuntu" ]]; then
+			_ubuntu_self_heal_cluster || true
+		elif [[ "${OS_FAMILY}" == "rhel" ]]; then
+			_rhel_self_heal_cluster || true
+		fi
+	fi
+
 	log "Provisioning PostgreSQL ${PG_VERSION} on ${OS_FAMILY} (repo=${REPO_KIND})"
 	if [[ "$DRY_RUN" == "true" ]]; then
 		log "Dry-run: would prepare repos, install packages, and configure"

--- a/tests/test_dropin_config.py
+++ b/tests/test_dropin_config.py
@@ -1,0 +1,56 @@
+import pytest
+
+
+def _make_stub(tmpdir, name, body="#!/bin/sh\nexit 0"):
+    p = tmpdir / name
+    p.write_text(body + "\n", encoding="utf-8")
+    p.chmod(0o755)
+    return p
+
+
+@pytest.mark.unit
+def test_apply_dropin_idempotent_and_content(tmp_path, bash):
+    # Stubs to avoid root requirements
+    _make_stub(tmp_path, "chown")
+    _make_stub(tmp_path, "restorecon")
+    _make_stub(
+        tmp_path,
+        "install",
+        body=r"""#!/bin/sh
+# naive install -d stub: create last arg dir
+last=""
+for a in "$@"; do last="$a"; done
+mkdir -p "$last"
+exit 0
+""",
+    )
+
+    conf = tmp_path / "postgresql.conf"
+    conf.write_text("# base\n", encoding="utf-8")
+    data = tmp_path / "data"
+    data.mkdir()
+
+    script = f"""
+      export PATH="{tmp_path}:$PATH"
+      PORT=5433
+      LISTEN_ADDRESSES="*"
+      UNIX_SOCKET_GROUP=pgclients
+      UNIX_SOCKET_PERMISSIONS=0770
+      ENABLE_TLS=false
+      SUDO=()  # ensure wrappers don't try sudo
+
+      apply_dropin_config "{conf}" "{data}"
+      apply_dropin_config "{conf}" "{data}"   # idempotent
+    """
+    r = bash(script)
+    assert r.rc == 0, r.stderr
+
+    # Validate include_dir appears exactly once
+    conf_text = conf.read_text(encoding="utf-8")
+    assert conf_text.count("include_dir = 'conf.d'") == 1
+
+    dropin = conf.parent / "conf.d" / "99-pgprovision.conf"
+    body = dropin.read_text(encoding="utf-8")
+    assert "port = 5433" in body
+    assert "listen_addresses = '*'" in body
+    assert "shared_preload_libraries = 'pg_stat_statements'" in body

--- a/tests/test_pgdata.py
+++ b/tests/test_pgdata.py
@@ -1,0 +1,52 @@
+import shutil
+import pytest
+
+
+@pytest.mark.unit
+def test_is_valid_pgdata_accepts_symlinked_wal(tmp_path, bash):
+    # Arrange: build a minimal, valid PGDATA with symlinked pg_wal
+    pg = tmp_path / "pgdata"
+    (pg / "global").mkdir(parents=True)
+    (pg / "base").mkdir()
+    (pg / "global" / "pg_control").write_bytes(b"X")
+    (pg / "PG_VERSION").write_text("16\n", encoding="utf-8")
+    wal = tmp_path / "wal"
+    wal.mkdir()
+    (pg / "pg_wal").symlink_to(wal)
+
+    script = f"""
+      OS_FAMILY=ubuntu; PG_VERSION=16; load_os_module
+      _is_valid_pgdata "{pg}"
+      echo RC=$?
+    """
+    r = bash(script)
+    assert r.rc == 0, r.stderr
+    assert "RC=0" in r.stdout  # success
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("osfam", ["rhel", "ubuntu"])
+@pytest.mark.parametrize("missing", ["PG_VERSION", "global/pg_control", "base"])
+def test_is_valid_pgdata_fails_when_core_piece_missing(tmp_path, bash, osfam, missing):
+    pg = tmp_path / "pgdata"
+    (pg / "global").mkdir(parents=True)
+    (pg / "base").mkdir()
+    (pg / "PG_VERSION").write_text("16\n", encoding="utf-8")
+    (pg / "global" / "pg_control").write_bytes(b"X")
+    (pg / "pg_wal").mkdir()
+    # Remove the one we want missing
+    if missing == "PG_VERSION":
+        (pg / "PG_VERSION").unlink()
+    elif missing == "global/pg_control":
+        (pg / "global" / "pg_control").unlink()
+    elif missing == "base":
+        shutil.rmtree(pg / "base")
+
+    script = f"""
+      OS_FAMILY={osfam}; PG_VERSION=16; load_os_module
+      if _is_valid_pgdata "{pg}"; then echo RC=0; else echo RC=$?; fi
+    """
+
+    r = bash(script)
+    assert r.rc == 0, r.stderr
+    assert "RC=1" in r.stdout  # failure

--- a/tests/test_rhel_self_heal.py
+++ b/tests/test_rhel_self_heal.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+def _make_stub(tmpdir, name, body='#!/bin/sh\necho STUB:$0 "$@"'):
+    p = tmpdir / name
+    p.write_text(body + "\n", encoding="utf-8")
+    p.chmod(0o755)
+    return p
+
+
+@pytest.mark.unit
+def test_rhel_heal_noop_when_unit_missing(tmp_path, bash):
+    # Stub systemctl: 'list-unit-files' succeeds (no versioned unit),
+    # but 'cat' fails to simulate unit not installed yet.
+    _make_stub(
+        tmp_path,
+        "systemctl",
+        body=r"""#!/bin/sh
+case "$1" in
+  list-unit-files) exit 0 ;;
+  cat) exit 1 ;;
+  *) exit 0 ;;
+esac
+""",
+    )
+
+    script = f"""
+      export PATH="{tmp_path}:$PATH"
+      OS_FAMILY=rhel; PG_VERSION=16; load_os_module
+      _rhel_self_heal_cluster
+    """
+    r = bash(script)
+    assert r.rc == 0, r.stderr
+    # No warning spam before packages/units exist
+    assert "RHEL self-heal: detected broken cluster" not in r.stdout

--- a/tests/test_self_heal_flag.py
+++ b/tests/test_self_heal_flag.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.mark.unit
+def test_self_heal_flag_default_true(bash):
+    script = r"""
+      : "${SELF_HEAL:=unset}"
+      # parse_args sets defaults (SELF_HEAL default should be true)
+      parse_args --dry-run
+      printf 'SELF_HEAL=%s\n' "${SELF_HEAL}"
+    """
+    r = bash(script)
+    assert r.rc == 0, r.stderr
+    assert "SELF_HEAL=true" in r.stdout
+
+
+@pytest.mark.unit
+def test_self_heal_flag_disable(bash):
+    script = r"""
+      parse_args --no-self-heal --dry-run
+      printf 'SELF_HEAL=%s\n' "${SELF_HEAL}"
+    """
+    r = bash(script)
+    assert r.rc == 0, r.stderr
+    assert "SELF_HEAL=false" in r.stdout

--- a/tests/test_service_fallback.py
+++ b/tests/test_service_fallback.py
@@ -1,0 +1,39 @@
+import pathlib
+import pytest
+
+
+def _make_stub(
+    tmpdir: pathlib.Path, name: str, body: str = '#!/bin/sh\necho STUB:$0 "$@"'
+):
+    p = tmpdir / name
+    p.write_text(body + "\n", encoding="utf-8")
+    p.chmod(0o755)
+    return p
+
+
+@pytest.mark.unit
+def test_os_enable_and_start_fallback_without_systemd(tmp_path, bash):
+    # PATH contains only our stubs; no systemctl present.
+    _make_stub(tmp_path, "pg_ctlcluster")
+    script = rf"""
+      export PATH="{tmp_path}"
+      OS_FAMILY=ubuntu; PG_VERSION=16; load_os_module
+      os_enable_and_start "postgresql@16-main"
+    """
+    r = bash(script)
+    assert r.rc == 0, r.stderr
+    # Ensure fallback path invoked pg_ctlcluster
+    assert "+ pg_ctlcluster" in r.stdout
+
+
+@pytest.mark.unit
+def test_os_restart_fallback_without_systemd(tmp_path, bash):
+    _make_stub(tmp_path, "pg_ctlcluster")
+    script = rf"""
+      export PATH="{tmp_path}"
+      OS_FAMILY=ubuntu; PG_VERSION=16; load_os_module
+      os_restart "postgresql@16-main"
+    """
+    r = bash(script)
+    assert r.rc == 0, r.stderr
+    assert "+ pg_ctlcluster" in r.stdout


### PR DESCRIPTION
This pull request introduces robust "self-heal" logic for PostgreSQL cluster provisioning on both Ubuntu/Debian (PGDG) and RHEL-family systems, ensuring that broken or missing clusters are automatically detected and repaired in a non-destructive way. The implementation includes new preflight checks, safe adoption of existing data directories, and extensive documentation and test plan updates to cover these scenarios.

**Self-Heal Logic and Cluster Adoption:**

* Added `_ubuntu_self_heal_cluster` and `_rhel_self_heal_cluster` functions to detect and repair broken or missing PostgreSQL clusters before making changes, ensuring non-destructive adoption of valid `PGDATA` directories and safe initialization if none exist. This includes preflight checks for permissions, ownership, and version mismatches. [[1]](diffhunk://#diff-de8f1817b940006cb1eedec4cd587a2c754984537c677c8fdefcec1964ca6d3bR68-R316) [[2]](diffhunk://#diff-9942b528b387695ac11605d0033cf99790e229a1818dd0849554df7378a8d980R56-R218)
* Integrated self-heal preflight into the main cluster initialization flow (`os_init_cluster`) for both Ubuntu and RHEL, with the ability to disable via `SELF_HEAL=false`. [[1]](diffhunk://#diff-de8f1817b940006cb1eedec4cd587a2c754984537c677c8fdefcec1964ca6d3bR68-R316) [[2]](diffhunk://#diff-9942b528b387695ac11605d0033cf99790e229a1818dd0849554df7378a8d980R264-R278)
* Enhanced detection and quarantine of broken metadata/configuration on Ubuntu, moving out-of-place or corrupt cluster configs to a quarantine directory before proceeding.

**Testing and Documentation:**

* Expanded test plans for both Ubuntu and RHEL to cover self-heal scenarios, including adopting existing valid data directories and handling missing or invalid clusters. [[1]](diffhunk://#diff-d879b626c07b044b64401d25a99791ad82e118a91822d84ec8e6ba1526faab47R330-R380) [[2]](diffhunk://#diff-b96d741ae8e09f30ff482fe4d53a07d82c52a99151f156143c3e521c310f8f41R241-R297)
* Updated the `README.md` to document the new self-heal behavior, usage, and how to disable it, with references to the relevant test plan sections.

**Other Improvements:**

* Updated the release reference in the `README.md` to version 0.2.5.
* Switched the ShellCheck pre-commit hook to a new maintained repository and added the `-x` argument for improved shell script linting.
* Minor improvements to development setup instructions in the Ubuntu test plan.

These changes significantly improve the reliability and safety of PostgreSQL provisioning, especially in environments where clusters may become misconfigured or partially deleted.